### PR TITLE
Feat: support connections behind NAT

### DIFF
--- a/core/Extensions/AppExtensions.cs
+++ b/core/Extensions/AppExtensions.cs
@@ -49,7 +49,8 @@ public static class AppExtensions
             var remoteNodes = configuration.GetSection("Node:Network:SeedList").GetChildren().ToArray();
             var node = new Node
             {
-                EndPoint = new IPEndPoint(Util.GetIpAddress(), 0),
+
+                EndPoint = new IPEndPoint(IPAddress.Parse(configuration["Node:Network:PublicIPAddress"]), 0),
                 Name = configuration["Node:Name"],
                 Data =
                     new Data
@@ -61,6 +62,7 @@ public static class AppExtensions
                 {
                     Environment = configuration["Node:Network:Environment"],
                     CertificateMode = configuration["Node:Network:CertificateMode"],
+                    PublicIPAddress = configuration["Node:Network:PublicIPAddress"],
                     HttpPort = Convert.ToInt32(configuration["Node:Network:HttpPort"]),
                     HttpsPort = Convert.ToInt32(configuration["Node:Network:HttpsPort"]),
                     P2P =

--- a/core/Helper/Util.cs
+++ b/core/Helper/Util.cs
@@ -232,7 +232,7 @@ public static class Util
             }
         }
 
-        return IPAddress.Loopback;
+        return IPAddress.Any;
     }
 
     /// <summary>

--- a/core/Models/NetworkSetting.cs
+++ b/core/Models/NetworkSetting.cs
@@ -33,6 +33,7 @@ public record Network
     public X509Certificate X509Certificate { get; set; }
     public TransactionLeakRateConfigurationOption MemoryPoolTransactionRateLimit { get; set; }
     public string SigningKeyRingName { get; set; }
+    public string PublicIPAddress { get; set; }
     public int HttpPort { get; set; }
     public int HttpsPort { get; set; }
     public P2P P2P { get; set; }

--- a/core/Network/P2PDevice.cs
+++ b/core/Network/P2PDevice.cs
@@ -126,10 +126,10 @@ public sealed class P2PDevice : IP2PDevice, IDisposable
     {
         Util.ThrowPortNotFree(_systemCore.Node.Network.P2P.TcpPort);
         _systemCore.Node.EndPoint.Port = _systemCore.Node.Network.P2P.TcpPort;
-        ListeningAsync(new(Util.GetIpAddress(), 0), Transport.Tcp, 5).ConfigureAwait(false);
+        ListeningAsync(new(Util.GetIpAddress(), _systemCore.Node.EndPoint.Port), Transport.Tcp, 5).ConfigureAwait(false);
         Util.ThrowPortNotFree(_systemCore.Node.Network.P2P.WsPort);
         _systemCore.Node.EndPoint.Port = _systemCore.Node.Network.P2P.WsPort;
-        ListeningAsync(new(Util.GetIpAddress(), 0), Transport.Ws, 1).ConfigureAwait(false);
+        ListeningAsync(new(Util.GetIpAddress(), _systemCore.Node.EndPoint.Port), Transport.Ws, 1).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/core/Network/P2PDevice.cs
+++ b/core/Network/P2PDevice.cs
@@ -126,10 +126,10 @@ public sealed class P2PDevice : IP2PDevice, IDisposable
     {
         Util.ThrowPortNotFree(_systemCore.Node.Network.P2P.TcpPort);
         _systemCore.Node.EndPoint.Port = _systemCore.Node.Network.P2P.TcpPort;
-        ListeningAsync(_systemCore.Node.EndPoint, Transport.Tcp, 5).ConfigureAwait(false);
+        ListeningAsync(new(Util.GetIpAddress(), 0), Transport.Tcp, 5).ConfigureAwait(false);
         Util.ThrowPortNotFree(_systemCore.Node.Network.P2P.WsPort);
         _systemCore.Node.EndPoint.Port = _systemCore.Node.Network.P2P.WsPort;
-        ListeningAsync(_systemCore.Node.EndPoint, Transport.Ws, 1).ConfigureAwait(false);
+        ListeningAsync(new(Util.GetIpAddress(), 0), Transport.Ws, 1).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/core/Network/PeerDiscovery.cs
+++ b/core/Network/PeerDiscovery.cs
@@ -214,7 +214,7 @@ public sealed class PeerDiscovery : IDisposable, IPeerDiscovery
     private Task DiscoverAsync()
     {
         Util.ThrowPortNotFree(_systemCore.Node.Network.P2P.DsPort);
-        var ipEndPoint = new IPEndPoint(_systemCore.Node.EndPoint.Address,
+        var ipEndPoint = new IPEndPoint(Util.GetIpAddress(),
             _systemCore.Node.Network.P2P.DsPort);
         _socket = NngFactorySingleton.Instance.Factory.SurveyorOpen()
             .ThenListen($"tcp://{ipEndPoint.Address}:{ipEndPoint.Port}", Defines.NngFlag.NNG_FLAG_NONBLOCK).Unwrap();

--- a/node/Configuration/Utility.cs
+++ b/node/Configuration/Utility.cs
@@ -72,7 +72,7 @@ public class Utility
                     .AddColumn(new TableColumn("Setting").Centered())
                     .AddColumn(new TableColumn("Value").Centered())
                     .AddRow("Name", _node.Name)
-                    .AddRow("IP Address", _node.EndPoint.Address.ToString())
+                    .AddRow("IP Address", _node.Network.PublicIPAddress)
                     .AddRow("Http Port", _node.Network.HttpPort.ToString())
                     .AddRow("Tcp Port", _node.Network.P2P.TcpPort.ToString())
                     .AddRow("Web Socket Port", _node.Network.P2P.WsPort.ToString())
@@ -138,10 +138,13 @@ public class Utility
         if (ipAddressChoice == ManuallyEnterIpAddress)
         {
             var foundIpAddress = TangramXtgm.Helper.Util.GetIpAddress();
-            if (AnsiConsole.Confirm($"IP address found {foundIpAddress}"))
+            if (foundIpAddress != IPAddress.Any)
             {
-                _node.EndPoint = new(foundIpAddress, 0);
-                return;
+                if (AnsiConsole.Confirm($"IP address found {foundIpAddress}"))
+                {
+                    _node.Network.PublicIPAddress = foundIpAddress.ToString();
+                    return;
+                }
             }
 
             var ipAddress = AnsiConsole.Prompt(new TextPrompt<string>("Enter IP address (e.g. 123.1.23.123):")
@@ -154,7 +157,7 @@ public class Utility
                         false => ValidationResult.Error("[red]Something went wrong[/]")
                     };
                 }));
-            _node.EndPoint = new(IPAddress.Parse(ipAddress), 0);
+            _node.Network.PublicIPAddress = ipAddress.ToString();
         }
         else
         {
@@ -162,7 +165,7 @@ public class Utility
                 .Title("Please choose the service to use for automatic IP address detection")
                 .AddChoices(new[] { "ident.me", "ipify.org", "my-ip.io", "seeip.org" }));
             var selectedIpAddressService = _ipServices.First(service => service.Name == serviceChoice);
-            _node.EndPoint = new(selectedIpAddressService.Read(), 0);
+            _node.Network.PublicIPAddress = selectedIpAddressService.Read().ToString();
         }
     }
 

--- a/node/appsettings.json
+++ b/node/appsettings.json
@@ -7,12 +7,13 @@
     },
     "Staking": {
       "MaxTransactionsPerBlock": 133,
-      "MaxTransactionSizePerBlock" : 2102400
+      "MaxTransactionSizePerBlock": 2102400
     },
     "Network": {
+      "PublicIPAddress": "0.0.0.0",
       "HttpPort": 48655,
       "HttpsPort": 44333,
-      "P2P" : {
+      "P2P": {
         "TcpPort": 7946,
         "WsPort": 7947,
         "DsPort": 5146
@@ -26,10 +27,12 @@
       "AutoSyncEveryMinutes": 10,
       "PeerCooldownMinutes": 30,
       "CertificateMode": "self",
-      "MaxBlockSize" : 2102912,
+      "MaxBlockSize": 2102912,
       "LettuceEncrypt": {
         "AcceptTermsOfService": true,
-        "DomainNames": [ "tangram.xtgm" ],
+        "DomainNames": [
+          "tangram.xtgm"
+        ],
         "EmailAddress": "dev@tangram.xtgm"
       },
       "X509Certificate": {
@@ -65,7 +68,7 @@
         "Args": {
           "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
           "path": "xtgmnode.log",
-          "fileSizeLimitBytes" : 1048576,
+          "fileSizeLimitBytes": 1048576,
           "rollOnFileSizeLimit": true,
           "rollingInterval": "Day",
           "retainedFileCountLimit": 7


### PR DESCRIPTION
# Description

This PR adds support for nodes using IP addresses that are not assigned to its network interface (ie. NATs, AWS, Google Cloud).

A new attribute `PublicIPAddress` has been added to the model `Network` to persist the selected public IP used by the node (whether manually entered or auto-detected). This new Attribute is used when constructing the `Node` object on `AddSystemCore`. Changing this attribute, however, only fixed the issue of a private IP being broadcasted to the network; peer-related services and the HTTP API endpoint required additional modifications.
If an IP not assigned to the instance's network interface is used to open a socket on windows the error code `WSAEADDRNOTAVAIL` is thrown, this makes using the  `PublicIPAddress` parameter unviable.
To solve this issue, the method `GetIpAddress` now fallbacks to IPAddress.Any (0.0.0.0) instead of IPAddress.Loopback, thus remaining compatible with implementations where localhost usage is needed, and also serving our original purpose. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

These changes have been tested on AWS and DigitalOcean.

- [x] AWS (Ubuntu)
- [x] DigitalOcean  (Ubuntu)
- [x] Residential NAT (Windows)

To test these changes, you can use the following install script (or [fork](https://github.com/itsMarcoSolis/tangram/tree/migrate-install-script) and build yourself)

 `bash <(curl -sSL https://raw.githubusercontent.com/itsMarcoSolis/tangram/migrate-install-script/install/install.sh)`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings